### PR TITLE
Fix unhandled promise rejection error on failed persistent subscription on start

### DIFF
--- a/src/eventStorePersistentSubscriptionBase.js
+++ b/src/eventStorePersistentSubscriptionBase.js
@@ -35,12 +35,17 @@ EventStorePersistentSubscriptionBase.prototype.start = function() {
   this._stopped = false;
 
   var self = this;
-  this._startSubscription(this._subscriptionId, this._streamId, this._bufferSize, this._userCredentials,
+  var promise = this._startSubscription(this._subscriptionId, this._streamId, this._bufferSize, this._userCredentials,
                           this._onEventAppeared.bind(this), this._onSubscriptionDropped.bind(this), this._settings)
       .then(function(subscription) {
         console.log('Subscription started.');
         self._subscription = subscription;
       });
+  if (this._onSubscriptionDropped !== null) {
+    promise.catch(function(error) {
+      self._onSubscriptionDropped(this, error.message, error);
+    })
+  }
 };
 
 EventStorePersistentSubscriptionBase.prototype._startSubscription = function() {


### PR DESCRIPTION
`EventStorePersistentSubscriptionBase.prototype.start` invokes a promise, but does not catch the error. This behavior is deprecated:

> (node:15285) [DEP0018] DeprecationWarning: Unhandled promise rejections are deprecated. In the future, promise rejections that are not handled will terminate the Node.js process with a non-zero exit code.

To resolve this, I passed the error along to the `subscriptionDropped` callback.