### PR TITLE
Upgrade jsdoc to version 3.5.5

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "uuid": "^3.0.1"
   },
   "devDependencies": {
-    "jsdoc": "^3.5.3",
+    "jsdoc": "^3.5.5",
     "nodeunit": "^0.11.1",
     "webpack": "^3.3.0"
   }


### PR DESCRIPTION
Running `yarn install` with jsdoc v3.5.3 produces the following error:
```
> rm -rf docs && jsdoc src -r -d docs

fs.js:1973
  binding.copyFile(src, dest, flags);
          ^

Error: EISDIR: illegal operation on a directory, copyfile 'node-eventstore-client/node_modules/jsdoc/templates/default/static/fonts/OpenSans-Bold-webfont.eot' -> 'docs/fonts'
    at Object.fs.copyFileSync (fs.js:1973:11)
    at node-eventstore-client/node_modules/jsdoc/templates/default/publish.js:516:12
    at Array.forEach (<anonymous>)
    at Object.exports.publish (node-eventstore-client/node_modules/jsdoc/templates/default/publish.js:512:17)
    at Object.module.exports.cli.generateDocs node-eventstore-client/node_modules/jsdoc/cli.js:448:35)
    at Object.module.exports.cli.processParseResults (node-eventstore-client/node_modules/jsdoc/cli.js:399:20)
    at module.exports.cli.main (node-eventstore-client/node_modules/jsdoc/cli.js:240:14)
    at Object.module.exports.cli.runCommand (node-eventstore-client/node_modules/jsdoc/cli.js:189:5)
    at node-eventstore-client/node_modules/jsdoc/jsdoc.js:105:9
    at Object.<anonymous> (node-eventstore-client/node_modules/jsdoc/jsdoc.js:106:3)
    at Module._compile (module.js:660:30)
    at Object.Module._extensions..js (module.js:671:10)
    at Module.load (module.js:573:32)
    at tryModuleLoad (module.js:513:12)
    at Function.Module._load (module.js:505:3)
    at Function.Module.runMain (module.js:701:10)
npm ERR! code ELIFECYCLE
npm ERR! errno 1
npm ERR! node-eventstore-client@0.2.1 gendocs: `rm -rf docs && jsdoc src -r -d docs`
npm ERR! Exit status 1
npm ERR! 
npm ERR! Failed at the node-eventstore-client@0.2.1 gendocs script.
```
Upgrading to jsdoc v3.5.5 seems to resolve this issue. 

(node v9.5.0, npm v5.6.0, yarn v1.3.2, Arch Linux)