### PR TITLE
Send Content-Length to eliminate missing Content-Type error in some cases

### DIFF
--- a/src/projections/projectionsClient.js
+++ b/src/projections/projectionsClient.js
@@ -139,6 +139,7 @@ ProjectionsClient.prototype.request = function(method, _url, data, userCredentia
     });
     req.on('error', reject);
     if (data) {
+      req.setHeader('Content-Length', data.length);
       req.setHeader('Content-Type', 'application/json');
       req.write(data);
     }


### PR DESCRIPTION
We are having trouble managing projections on our eventstore cluster. Locally there were no problems but apparently in our production setup things work slightly different. Dont ask me why, but this PR fixes the 'Missing or invalid Content-Type' message.