### PR TITLE
Adds EventEmitter declarations to EventStoreNodeConnection 

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,6 +1,9 @@
 /// <reference types="node" />
 /// <reference types="Long" />
 
+import { EventEmitter } from "events";
+import { StrictEventEmitter } from "strict-event-emitter-types";
+
 // Expose classes
 export class Position {
     constructor(commitPosition: number|Long, preparePosition: number|Long);
@@ -305,7 +308,18 @@ export interface EventData {
     readonly metadata: Buffer;
 }
 
-export interface EventStoreNodeConnection {
+interface EventStoreNodeConnectionEvents {
+    connected: TcpEndPoint;
+    disconnected: TcpEndPoint;
+    reconnecting: void;
+    closed:string;
+    error: Error;
+    heartbeatInfo: HeartbeatInfo;
+}
+
+type EventStoreNodeConnectionEventEmitter = StrictEventEmitter<EventEmitter, EventStoreNodeConnectionEvents>;
+
+export class EventStoreNodeConnection extends (EventEmitter as { new(): EventStoreNodeConnectionEventEmitter }) {
     connect(): Promise<void>;
     close(): void;
     // write actions
@@ -332,9 +346,6 @@ export interface EventStoreNodeConnection {
     // metadata actions
     setStreamMetadataRaw(stream: string, expectedMetastreamVersion: Long|number, metadata: any, userCredentials?: UserCredentials): Promise<WriteResult>;
     getStreamMetadataRaw(stream: string, userCredentials?: UserCredentials): Promise<RawStreamMetadataResult>;
-
-    on(event: "connected" | "disconnected" | "reconnecting" | "closed" | "error" | "heartbeatInfo", listener: (arg: Error | string | TcpEndPoint | HeartbeatInfo) => void): this;
-    once(event: "connected" | "disconnected" | "reconnecting" | "closed" | "error" | "heartbeatInfo", listener: (arg: Error | string | TcpEndPoint | HeartbeatInfo) => void): this;
 }
 
 // Expose helper functions

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
   "dependencies": {
     "@types/long": "^3.0.31",
     "@types/node": "^6.0.47",
+    "strict-event-emitter-types": "^1.2.0",
     "long": "^3.2",
     "protobufjs": "^6.7.3",
     "uuid": "^3.0.1"


### PR DESCRIPTION
Changed the typescript declarations of EventStoreNodeConnection so that they includes all EventEmitter methods.

The strict event declarations are improved so that the handlers of a particular event can't use a wrong definition of the offered param. For that the dependency "strict-event-emitter-types" is used which does not affect the runtime code. But it needs a TypeScript version >= 2.8 (I haven't used the newest version of that dependency because it would need a TypeScript version >= 3.0 and the new features are not needed here).

Please verify if a TypeScript version >= 2.8 is ok and if I have assigned the parameters of the events correctly.