### PR TITLE
Fix error with logging in SimpleQueuedHandler handler

### DIFF
--- a/src/core/simpleQueuedHandler.js
+++ b/src/core/simpleQueuedHandler.js
@@ -13,11 +13,12 @@ function SimpleQueuedHandler(log) {
 
 SimpleQueuedHandler.prototype.registerHandler = function(type, handler) {
   var typeId = typeName(type);
+  var log = this._log;
   this._handlers[typeId] = function (msg) {
     try {
       handler(msg);
     } catch(e) {
-      this._log.error('handle for', type, 'failed:', e.stack);
+      log.error('handle for', type, 'failed:', e.stack);
     }
   };
 };


### PR DESCRIPTION
Fixing this issue:
```
TypeError: Cannot read property 'error' of undefined
    at Immediate._handlers.(anonymous function) [as _onImmediate] (/home/indigenet/indigenet-pos/node_modules/node-eventstore-client/lib/dist.js:3774:17)
    at runCallback (timers.js:812:20)
    at tryOnImmediate (timers.js:768:5)
    at processImmediate [as _immediateCallback] (timers.js:745:5)
```