### PR TITLE
Make type definition of expectedVersion match implementation

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -125,6 +125,7 @@ export namespace expectedVersion {
     const any: number;
     const noStream: number;
     const emptyStream: number;
+    const streamExists: number;
 }
 
 export namespace positions {


### PR DESCRIPTION
https://github.com/nicdex/node-eventstore-client/blob/02642c5cfb664e75e29e151374c2df87b7e607d8/src/client.js#L4-L9

https://github.com/nicdex/node-eventstore-client/blob/02642c5cfb664e75e29e151374c2df87b7e607d8/index.d.ts#L124-L128

This PR adds the missing `streamExists` variant.